### PR TITLE
Fixing how RRs are propagated from blockchain to DB #32

### DIFF
--- a/dens-query/api/lbf/Dens/Db.lbf
+++ b/dens-query/api/lbf/Dens/Db.lbf
@@ -60,7 +60,7 @@ instance PlutusData DensRr
 -- configuration of the entire protocol
 record DensProtocolUtxo = 
     { txOutRef: TxOutRef
-    , protocol : Protocol
+    , protocol: Protocol
     }
 derive Eq DensProtocolUtxo
 derive Json DensProtocolUtxo

--- a/dens-query/api/postgres/dens.sql
+++ b/dens-query/api/postgres/dens.sql
@@ -2,7 +2,7 @@
 -- For each "kind of UTxO" for the dens protocol, we create a table for it e.g.
 -- we have tables
 --  - `+dens_set_utxos+`
---  - `+dens_rrs_utxos+`
+--  - `+dens_elem_ids+`
 --  - `+dens_protocol_utxos+`
 -- We call such a table a _dens table_.
 -- Each of these dens tables has a foreign key to `+tx_out_refs+` s.t. when a
@@ -37,6 +37,22 @@
 -- * [#ogmios] https://ogmios.dev/api/
 
 -----------------------------------------------------------------------------
+-- = Types
+-----------------------------------------------------------------------------
+CREATE TYPE asset_class_type AS (
+    currency_symbol bytea,
+    token_name bytea
+);
+
+CREATE DOMAIN asset_class AS asset_class_type 
+CONSTRAINT currency_symbol_not_null CHECK (((VALUE).currency_symbol IS NOT NULL))
+CONSTRAINT token_name_not_null CHECK (((VALUE).token_name IS NOT NULL))
+-- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs#L75-L92
+CONSTRAINT currency_symbol_length CHECK ((octet_length((VALUE).currency_symbol) = 0) OR (octet_length((VALUE).currency_symbol) = 28))
+-- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs#L99-L112
+CONSTRAINT token_name_length CHECK (octet_length((VALUE).token_name) <= 32);
+
+-----------------------------------------------------------------------------
 -- = Tables for general information about the blockchain
 -----------------------------------------------------------------------------
 
@@ -61,6 +77,9 @@ CREATE TABLE IF NOT EXISTS tx_out_refs (
 
     FOREIGN KEY (block_id, block_slot) REFERENCES blocks (block_id, block_slot)
     ON DELETE CASCADE DEFERRABLE,
+
+    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs#L51-L65
+    CONSTRAINT tx_id_length_is_32 CHECK (octet_length(tx_out_ref_id) = 32),
  
     PRIMARY KEY (tx_out_ref_id, tx_out_ref_idx)
 );
@@ -82,60 +101,9 @@ CREATE TABLE IF NOT EXISTS dens_set_utxos (
 
     -- Token which associates this `+name+` with a validator address which
     -- actually holds (a reference) to the RRs.
-    currency_symbol bytea,
-    token_name bytea,
+    pointer asset_class NOT NULL,
 
     tx_out_ref_id bytea NOT NULL,
-    tx_out_ref_idx bigint NOT NULL,
-
-    PRIMARY KEY (tx_out_ref_id, tx_out_ref_idx),
-
-    FOREIGN KEY (tx_out_ref_id, tx_out_ref_idx) REFERENCES tx_out_refs (tx_out_ref_id, tx_out_ref_idx)
-    ON DELETE CASCADE DEFERRABLE,
-
-    CONSTRAINT currency_symbol_and_token_name_both_present_or_not CHECK
-    (
-        (currency_symbol IS null AND token_name IS null)
-        OR (currency_symbol IS NOT null AND token_name IS NOT null)
-    ),
-
-    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs#L75-L92
-    CONSTRAINT currency_symbol_length_0_or_28 CHECK
-    (
-        (octet_length(currency_symbol) = 0) OR (octet_length(currency_symbol) = 28)
-    ),
-
-    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs#L99-L112
-    CONSTRAINT token_name_length_at_most_32 CHECK (octet_length(token_name) <= 32),
-
-    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs#L51-L65
-    CONSTRAINT tx_id_length_is_32 CHECK (octet_length(tx_out_ref_id) = 32)
-);
-
--- Index s.t. one can efficiently query if change has happened in the
--- dens_set_utxos
-CREATE INDEX IF NOT EXISTS dens_set_utxos_currency_symbol_token_name ON dens_set_utxos (currency_symbol, token_name);
-
--- Index s.t. one can efficiently query which UTxO to spend
-CREATE INDEX IF NOT EXISTS dens_set_utxos_name ON dens_set_utxos (name);
-
-
------------------------------------------------------------------------------
--- == Table for representing the UTxOs which contain RRs
------------------------------------------------------------------------------
-
--- `+DensValidator+`s with pointer to the `+dens_set_utxos+` i.e., we have 
---      - M:1 relationship of many DensValidator to 1 dens_set_utxos
-CREATE TABLE IF NOT EXISTS dens_rrs_utxos (
-    -- Foreign key to the dens_set_utxos
-    name bytea REFERENCES dens_set_utxos (name)
-    ON DELETE CASCADE DEFERRABLE,
-
-    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs#L51-L65
-    CONSTRAINT tx_id_length_is_32 CHECK (octet_length(tx_out_ref_id) = 32),
-
-    tx_out_ref_id bytea NOT NULL,
-
     tx_out_ref_idx bigint NOT NULL,
 
     PRIMARY KEY (tx_out_ref_id, tx_out_ref_idx),
@@ -144,11 +112,52 @@ CREATE TABLE IF NOT EXISTS dens_rrs_utxos (
     ON DELETE CASCADE DEFERRABLE
 );
 
--- Index s.t. we can efficiently join dens_set_utxos with dens_rrs_utxos on the name
-CREATE INDEX IF NOT EXISTS dens_rrs_utxos_name_index ON dens_rrs_utxos (name);
+-- Index s.t. one can efficiently query if change has happened in the
+-- dens_set_utxos
+CREATE INDEX IF NOT EXISTS dens_set_utxos_asset_class ON dens_set_utxos (pointer);
+
+-- Index s.t. one can efficiently query which UTxO to spend
+CREATE INDEX IF NOT EXISTS dens_set_utxos_name ON dens_set_utxos (name);
+
+-----------------------------------------------------------------------------
+-- == Table for representing the UTxOs which contain RRs
+-----------------------------------------------------------------------------
+
+-- `+TxOutRef+`s which contain the dens_set_utxos(pointer)
+-- i.e., these are the UTxOs which identify the transactions which contain
+-- transaction outputs that contain RRs as datum.
+CREATE TABLE IF NOT EXISTS dens_elem_ids (
+    id bigserial UNIQUE,
+
+    tx_out_ref_id bytea NOT NULL,
+
+    tx_out_ref_idx bigint NOT NULL,
+
+    asset_class asset_class NOT NULL,
+
+    PRIMARY KEY(id),
+
+    UNIQUE (asset_class),
+
+    UNIQUE (tx_out_ref_id, tx_out_ref_idx, asset_class),
+
+    FOREIGN KEY (tx_out_ref_id, tx_out_ref_idx) REFERENCES tx_out_refs (tx_out_ref_id, tx_out_ref_idx)
+    ON DELETE CASCADE DEFERRABLE
+);
+
+CREATE INDEX IF NOT EXISTS dens_elem_ids_asset_classes ON dens_elem_ids(asset_class);
 
 -- The list of RRs at `+DensValidator+`s addresses i.e., this forms a
--- . M:1 relationship of `+dens_rrs+` to `+dens_rrs_utxos+`
+-- . M:1 relationship of `+dens_rrs+` to `+dens_elem_ids+`
+--
+-- NOTE:(jaredponn): so unlike the rest of the tables, the UTxOs we are
+-- interested in are controlled by how an asset class at `+dens_elem_ids+`
+-- is traded i.e.,
+--
+-- . If the asset class at `+dens_elem_ids+` is traded (i.e., if this
+--    UTxO is consumed), then the RRs are deleted
+-- 
+-- Contrast this to how all other tables have FKs to the `+tx_out_refs+` table
 --
 -- NOTE(jaredponn): this loosely follows the records table in
 -- <https://github.com/PowerDNS/pdns/blob/0b6eb67e14ce894e8286c0993e393b1191411c96/modules/gpgsqlbackend/schema.pgsql.sql>
@@ -163,10 +172,6 @@ CREATE INDEX IF NOT EXISTS dens_rrs_utxos_name_index ON dens_rrs_utxos (name);
 CREATE TABLE IF NOT EXISTS dens_rrs (
     id bigserial,
 
-    tx_out_ref_id bytea NOT NULL,
-
-    tx_out_ref_idx bigint NOT NULL,
-
     -- The type of the RR e.g. `+A+`, `+AAAA+`, etc.
     type varchar(10) NOT NULL,
 
@@ -174,9 +179,11 @@ CREATE TABLE IF NOT EXISTS dens_rrs (
 
     content varchar(65535) NOT NULL,
 
+    dens_elem_id bigserial,
+
     PRIMARY KEY(id),
 
-    FOREIGN KEY (tx_out_ref_id, tx_out_ref_idx) REFERENCES dens_rrs_utxos (tx_out_ref_id, tx_out_ref_idx)
+    FOREIGN KEY (dens_elem_id) REFERENCES dens_elem_ids(id)
     ON DELETE CASCADE DEFERRABLE
 );
 
@@ -214,17 +221,7 @@ CREATE TABLE IF NOT EXISTS dens_protocol_utxos (
 -- See `+dens_set_protocol_nft+` for details.
 CREATE TABLE IF NOT EXISTS dens_protocol_nft(
     at_most_one boolean PRIMARY KEY DEFAULT TRUE,
-    currency_symbol bytea NOT NULL,
-    token_name bytea NOT NULL,
-
-    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs#L75-L92
-    CONSTRAINT currency_symbol_length_0_or_28 CHECK
-    (
-        (octet_length(currency_symbol) = 0) OR (octet_length(currency_symbol) = 28)
-    ),
-
-    -- https://github.com/IntersectMBO/plutus/blob/1.16.0.0/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs#L99-L112
-    CONSTRAINT token_name_length_at_most_32 CHECK (octet_length(token_name) <= 32),
+    asset_class asset_class NOT NULL,
 
     CONSTRAINT at_most_one CHECK (at_most_one)
     );
@@ -658,9 +655,9 @@ SELECT create_table_undo_insert('dens_set_utxos');
 SELECT create_table_undo_delete('dens_set_utxos');
 SELECT create_table_undo_update('dens_set_utxos');
 
-SELECT create_table_undo_insert('dens_rrs_utxos');
-SELECT create_table_undo_delete('dens_rrs_utxos');
-SELECT create_table_undo_update('dens_rrs_utxos');
+SELECT create_table_undo_insert('dens_elem_ids');
+SELECT create_table_undo_delete('dens_elem_ids');
+SELECT create_table_undo_update('dens_elem_ids');
 
 SELECT create_table_undo_insert('dens_rrs');
 SELECT create_table_undo_delete('dens_rrs');
@@ -686,11 +683,10 @@ $body$
     BEGIN
         SELECT * INTO old_protocol_nft FROM dens_protocol_nft;
 
-        INSERT INTO dens_protocol_nft(currency_symbol, token_name)
-        VALUES(dens_set_protocol_nft.currency_symbol, dens_set_protocol_nft.token_name)
+        INSERT INTO dens_protocol_nft(asset_class)
+        VALUES(CAST(ROW(dens_set_protocol_nft.currency_symbol, dens_set_protocol_nft.token_name) AS asset_class))
         ON CONFLICT (at_most_one) DO UPDATE
-            SET currency_symbol = EXCLUDED.currency_symbol,
-                token_name = EXCLUDED.token_name;
+            SET asset_class = (EXCLUDED).asset_class;
 
         SELECT * INTO STRICT new_protocol_nft FROM dens_protocol_nft;
 
@@ -698,7 +694,7 @@ $body$
             RETURN new_protocol_nft;
         END IF;
 
-        IF old_protocol_nft.currency_symbol = new_protocol_nft.currency_symbol AND old_protocol_nft.token_name = new_protocol_nft.token_name THEN
+        IF (old_protocol_nft).asset_class = (new_protocol_nft).asset_class THEN
             RETURN new_protocol_nft;
         END IF;
 
@@ -726,7 +722,7 @@ $body$
         END IF;
 
         -- If the current protocol NFT matches the provided NFT, we're good, so do nothing and return
-        IF current_protocol_nft.currency_symbol = currency_symbol AND current_protocol_nft.token_name = token_name THEN
+        IF (current_protocol_nft).asset_class = ROW(currency_symbol, token_name) THEN
             RETURN current_protocol_nft;
         END IF;
 

--- a/dens-query/src/DensQuery/ChainSync.ts
+++ b/dens-query/src/DensQuery/ChainSync.ts
@@ -1,8 +1,5 @@
 /**
  * Functionality for syncing with the chain via ogmios.
- *
- * @private
- * Mostly taken from: {@link https://ogmios.dev/mini-protocols/local-chain-sync/ }
  */
 import * as OgmiosSchema from "@cardano-ogmios/schema";
 
@@ -36,7 +33,7 @@ export async function rollForwardDb(
       `slot` in block ? block.slot : "<no slot>"
     }`,
   );
-  logger.info(
+  logger.verbose(
     `Current Protocol AssetClass: ("${
       Buffer.from(protocolNft[0]).toString("hex")
     }", "${Buffer.from(protocolNft[1]).toString("hex")}")`,
@@ -66,15 +63,23 @@ export async function rollForwardDb(
 
         // 1.
         for (const txIn of tx.inputs) {
-          await client.deleteTxOutRef(
-            ogmiosTransactionOutputReferenceToPlaTxOutRef(txIn),
+          const txOutRef = ogmiosTransactionOutputReferenceToPlaTxOutRef(txIn);
+          logger.verbose(
+            `Consuming TxOutRef: ${
+              JSON.stringify(txOutRef, stringifyReplacer)
+            }`,
           );
+          await client.deleteTxOutRef(txOutRef);
         }
 
         // 2.
         for (let i = 0; i < tx.outputs.length; ++i) {
           const txOut: OgmiosSchema.TransactionOutput = tx.outputs[i]!;
           const txOutRef = { txOutRefId: txId, txOutRefIdx: BigInt(i) };
+
+          logger.verbose(
+            `Adding TxOutRef: ${JSON.stringify(txOutRef, stringifyReplacer)}`,
+          );
 
           // Add the TxOutRef
 

--- a/dens-query/src/DensQuery/Db.ts
+++ b/dens-query/src/DensQuery/Db.ts
@@ -573,7 +573,8 @@ export class DensDbClient {
     const res = await this.query(
       {
         text:
-          `SELECT * FROM (VALUES ((dens_sync_protocol_nft($1, $2)).*) ) AS t (pk, currency_symbol, token_name)`,
+          `SELECT (asset_class).currency_symbol AS currency_symbol, (asset_class).token_name AS token_name ` +
+          `FROM (VALUES ((dens_sync_protocol_nft($1, $2)).*) ) AS t (pk, asset_class)`,
         values: [currencySymbol, tokenName],
       },
     );

--- a/dens-query/src/DensQuery/Db.ts
+++ b/dens-query/src/DensQuery/Db.ts
@@ -657,8 +657,23 @@ export function validateDensRr(rr: DensRr): string | undefined {
     }
 
     case `SOA`: {
-      // TODO(jaredponn): write a quick regex to validate this.
+      // TODO(jaredponn): write a quick regex to validate this. Urgh, I'm not
+      // actually sure what PowerDNS expects here -- to my knowledge, this
+      // isn't documented... So we write a quick regex in an attempt to
+      // 'generalize' what it looks like it wants.
+      // See {@link https://doc.powerdns.com/authoritative/appendices/types.html#soa}..
+      // See 3.3.13. of {@link https://www.ietf.org/rfc/rfc1035.txt}
+      // And, dens_is_valid_name in api/postgres/dens.sql
+      const soaRegex =
+        /^(?<primary>([a-z]([-a-z0-9]*[a-z0-9])?)(.([a-z]([-a-z0-9]*[a-z0-9])?))*) (?<hostname>([a-z]([-a-z0-9]*[a-z0-9])?)(.([a-z]([-a-z0-9]*[a-z0-9])?))*) (?<serial>[0-9]+) (?<refresh>[0-9]+) (?<retry>[0-9]+) (?<expire>[0-9]+) (?<minimum>[0-9]+)$/g;
       const soa = Buffer.from(Uint8Array.from(rdata.fields)).toString();
+
+      const matches = soa.match(soaRegex);
+
+      if (matches === null) {
+        return undefined;
+      }
+
       return soa;
     }
   }

--- a/dens-query/src/DensQuery/Db.ts
+++ b/dens-query/src/DensQuery/Db.ts
@@ -273,8 +273,7 @@ export class DensDbClient {
     const res: QueryResult = await this.query(
       {
         text:
-          `SELECT element_id_minting_policy, set_elem_minting_policy, set_validator, records_validator, tx_out_ref_id, tx_out_ref_idx
-                   FROM dens_protocol_utxos`,
+          `SELECT element_id_minting_policy, set_elem_minting_policy, set_validator, records_validator, tx_out_ref_id, tx_out_ref_idx FROM dens_protocol_utxos`,
         values: [],
       },
     );
@@ -395,16 +394,16 @@ export class DensDbClient {
     if (content === undefined) {
       logger.info(
         `Invalid RR from the tx with output with dens elem id ${
-          JSON.stringify(elemAssetClass)
+          JSON.stringify(elemAssetClass, stringifyReplacer)
         } identifed by ${
           JSON.stringify(
             elemTxOutRef,
-            (_, v) => typeof v === "bigint" ? v.toString() : v,
+            stringifyReplacer,
           )
         }: ${
           JSON.stringify(
             rr,
-            (_, v) => typeof v === "bigint" ? v.toString() : v,
+            stringifyReplacer,
           )
         }`,
       );
@@ -635,7 +634,7 @@ export function transposeAssetClasses(
  */
 export function validateDensRr(rr: DensRr): string | undefined {
   // See 4.1.3 of <https://www.ietf.org/rfc/rfc1035.txt>
-  if (!(0 <= rr.ttl && rr.ttl <= (2 ^ 32 - 1))) {
+  if (!(0 <= rr.ttl && rr.ttl <= (2 ** 32 - 1))) {
     return undefined;
   }
 
@@ -677,5 +676,20 @@ export function validateDensRr(rr: DensRr): string | undefined {
 
       return soa;
     }
+  }
+}
+
+/**
+ * A "replacer" for `JSON.stringify` which:
+ *  - allows printing of big ints
+ *  - prints byte arrays in the hexadecimal representation
+ */
+function stringifyReplacer(_key: unknown, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  } else if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("hex");
+  } else {
+    return value;
   }
 }

--- a/dens-query/src/DensQuery/Db.ts
+++ b/dens-query/src/DensQuery/Db.ts
@@ -132,7 +132,7 @@ export class DensDb {
  * {@link DensDbClient} is a specific connection to the underlying database. In
  * particular, SQL transactions should all occur with the same client.
  */
-class DensDbClient {
+export class DensDbClient {
   #client: pg.ClientBase;
 
   constructor(client: pg.ClientBase) {
@@ -156,40 +156,40 @@ class DensDbClient {
   }
 
   /**
-   * {@link insertDensSetUtxo} inserts (or updates if it already exists) a
-   * {@link DensSetUtxo} in the database.
+   * {@link upsertDensSetUtxo} inserts (or updates the tx out refs of the name
+   * if it already exists) a {@link DensSetUtxo} in the database.
    */
-  async insertDensSetUtxo(
-    assetClassesAtTheUtxo: PlaV1.AssetClass[],
+  async upsertDensSetUtxo(
     { name, pointer, txOutRef }: DensSetUtxo,
   ) {
     const [currencySymbol, tokenName] = pointer;
-    const transposedAssetClassesAtTheUtxo: [CurrencySymbol[], TokenName[]] =
-      transposeAssetClasses(assetClassesAtTheUtxo);
     await this.query(
       {
-        // TODO(jaredponn): there's an easy optimization to not include the
-        // token names
-        text:
-          `INSERT INTO dens_set_utxos (name, currency_symbol, token_name, tx_out_ref_id, tx_out_ref_idx)
-                    (SELECT $3::bytea, $4::bytea, $5::bytea, $6::bytea, $7::bigint
-                     FROM dens_protocol_utxos
-                     WHERE set_elem_minting_policy IN 
-                        ( SELECT currency_symbol 
-                          FROM UNNEST($1::bytea[],$2::bytea[]) AS asset_classes_at_the_utxo(currency_symbol,token_name)
-                        )
-                     LIMIT 1
-                    )`,
+        text: `MERGE INTO dens_set_utxos ` +
+          `USING (VALUES(NULL)) AS foo ON name = $1 ` +
+          `WHEN MATCHED THEN UPDATE SET pointer = CAST(ROW($2, $3) AS asset_class), ` +
+          `tx_out_ref_id = $4, ` +
+          `tx_out_ref_idx = $5 ` +
+          `WHEN NOT MATCHED THEN INSERT(name, pointer, tx_out_ref_id, tx_out_ref_idx) ` +
+          `VALUES ($1, CAST(ROW($2, $3) AS asset_class), $4, $5)`,
+
+        // NOTE(jaredponn): Why don't we use upsert?
+        // We don't use a query as follows:
+        // ```
+        // `INSERT INTO dens_set_utxos (name, pointer, tx_out_ref_id, tx_out_ref_idx) ` +
+        // `VALUES ($1, CAST(ROW($2, $3) AS asset_class), $4, $5) ` +
+        // `ON CONFLICT (name) DO UPDATE SET tx_out_ref_id = EXCLUDED.tx_out_ref_id, tx_out_ref_idx = EXCLUDED.tx_out_ref_idx`,
+        // ```
+        // because it doesn't play nicely with undo logging i.e., in an
+        // "upsert", both the insert and update trigger
+        // would be fired which would "double delete" the key.
+        // We could fix this by checking if the row exists before adding the
+        // delete when adding the undo log, but then we'd
+        // lose concurrency guarantees
         values: [
-          transposedAssetClassesAtTheUtxo[0].map((bs) =>
-            Buffer.from(bs.buffer)
-          ),
-          transposedAssetClassesAtTheUtxo[1].map((bs) =>
-            Buffer.from(bs.buffer)
-          ),
           name,
-          currencySymbol,
-          tokenName,
+          Buffer.from(currencySymbol),
+          Buffer.from(tokenName),
           txOutRef.txOutRefId,
           txOutRef.txOutRefIdx,
         ],
@@ -223,8 +223,15 @@ class DensDbClient {
   ): Promise<void> {
     await this.query(
       {
-        text:
-          `INSERT INTO tx_out_refs VALUES ($1,$2, (get_most_recent_block()).*)`,
+        text: `MERGE INTO tx_out_refs ` +
+          `USING (VALUES (NULL)) AS foo ON tx_out_ref_id = $1 AND tx_out_ref_idx = $2 ` +
+          `WHEN NOT MATCHED THEN INSERT(tx_out_ref_id, tx_out_ref_idx, block_slot, block_id) ` +
+          `VALUES($1, $2, (get_most_recent_block()).*)`,
+        // NOTE(jaredponn): See NOTE(jaredponn): Why don't we use upsert?
+        // ```
+        // `INSERT INTO tx_out_refs VALUES ($1,$2, (get_most_recent_block()).*) ` +
+        // `ON CONFLICT DO NOTHING`,
+        // ```
         values: [txOutRefId, txOutRefIdx],
       },
     );
@@ -238,6 +245,28 @@ class DensDbClient {
         values: [txOutRefId, txOutRefIdx],
       },
     );
+  }
+
+  async selectProtocolNft(): Promise<PlaV1.AssetClass> {
+    const res: QueryResult = await this.query(
+      {
+        text:
+          `SELECT (asset_class).currency_symbol AS currency_symbol, (asset_class).token_name AS token_name ` +
+          `FROM dens_protocol_nft ` +
+          `LIMIT 1`,
+        values: [],
+      },
+    );
+    if (res.rows.length !== 1) {
+      throw new Error(`Protocol NFT has not been set yet`);
+    }
+
+    return [
+      Prelude.fromJust(
+        PlaV1.currencySymbolFromBytes(res.rows[0]!.currency_symbol),
+      ),
+      Prelude.fromJust(PlaV1.tokenNameFromBytes(res.rows[0]!.token_name)),
+    ] as PlaV1.AssetClass;
   }
 
   async selectProtocol(): Promise<DensProtocolUtxo | undefined> {
@@ -305,101 +334,109 @@ class DensDbClient {
   }
 
   /**
-   * Given all `assetClassesAtTheUtxo` at the UTxO, finds all `name`s which
-   * have an asset class in `assetClassesAtTheUtxo`, and adds the `name` +
-   * provided `rrs` + `txOutRef` to the table.
-   *
-   * Note that this ignores the `name` in {@link DensRrsUtxo}
+   * Inserts the dens elmeent UTxO
    */
-  async insertDensRrsUtxo(
-    assetClassesAtTheUtxo: PlaV1.AssetClass[],
-    { rrs, txOutRef }: DensRrsUtxo,
-  ): Promise<void> {
-    const transposedAssetClassesAtTheUtxo: [CurrencySymbol[], TokenName[]] =
-      transposeAssetClasses(assetClassesAtTheUtxo);
-
-    // First, we make note of the UTxO which contains the RRs
+  async insertDensElemIdUtxo(
+    mintedToken: PlaV1.AssetClass,
+    txOutRef: TxOutRef,
+  ) {
     await this.query(
       {
-        // NOTE(jaredponn): we don't use the following query since we need to
-        // be a bit clever on adding this to names which actually have it.
-        // ```
-        // text: `INSERT INTO dens_rrs_utxos VALUES($1,$2,$3,$4,$5,$6)`,
-        // ```
-        text: `INSERT INTO dens_rrs_utxos(name, tx_out_ref_id, tx_out_ref_idx)
-               SELECT name,$3::bytea,$4::bigint
-               FROM dens_set_utxos
-               WHERE (currency_symbol,token_name) IN (SELECT * FROM UNNEST($1::bytea[],$2::bytea[]) as asset_classes_at_the_utxo(currency_symbol,token_name))
-                    AND (dens_is_valid_name(name))
-               ON CONFLICT DO NOTHING
-                    `,
-        // Note that we ONLY add records which match the domains in
-        // Section 3.5 of
-        // <https://datatracker.ietf.org/doc/html/rfc1034> AND are
-        // lower case (this is to ensure adversaries can't add
-        // random RRs to someone elses things.
+        text:
+          `INSERT INTO dens_elem_ids(tx_out_ref_id, tx_out_ref_idx, asset_class) ` +
+          `VALUES ($1, $2, CAST(ROW($3, $4) AS asset_class))`,
         values: [
-          transposedAssetClassesAtTheUtxo[0].map((bs) =>
-            Buffer.from(bs.buffer)
-          ),
-          transposedAssetClassesAtTheUtxo[1].map((bs) =>
-            Buffer.from(bs.buffer)
-          ),
           Buffer.from(txOutRef.txOutRefId.buffer),
           txOutRef.txOutRefIdx,
+          Buffer.from(mintedToken[0]),
+          Buffer.from(mintedToken[1]),
         ],
       },
     );
+  }
 
-    // Then, we add the list of RRs
-    for (const rr of rrs) {
-      const { ttl } = rr;
-      const content = validateDensRr(rr);
+  /**
+   * Deletes the transaction outputs which contain the
+   */
+  async deleteDensElemIdTxOutRef(txOutRef: TxOutRef) {
+    await this.query(
+      {
+        text: `DELETE FROM dens_elem_ids ` +
+          `WHERE tx_out_ref_id = $1 AND tx_out_ref_idx = $2`,
+        values: [Buffer.from(txOutRef.txOutRefId.buffer), txOutRef.txOutRefIdx],
+      },
+    );
+  }
 
-      if (content === undefined) {
-        logger.info(
-          `Invalid RR at ${
-            JSON.stringify(
-              txOutRef,
-              (_, v) => typeof v === "bigint" ? v.toString() : v,
-            )
-          }: ${
-            JSON.stringify(
-              rr,
-              (_, v) => typeof v === "bigint" ? v.toString() : v,
-            )
-          }`,
-        );
-        continue;
-      }
+  /** Tests if the result is a valid name
+   */
+  async densIsValidName(name: Uint8Array): Promise<boolean> {
+    const result = await this.query(
+      {
+        text: `SELECT dens_is_valid_name($1)`,
+        values: [Buffer.from(name)],
+      },
+    );
 
-      await this.query(
-        {
-          text:
-            `INSERT INTO dens_rrs(tx_out_ref_id, tx_out_ref_idx, type, ttl, content)
-                       VALUES ($1, $2, $3, $4, $5)
-                            `,
-          values: [
-            Buffer.from(txOutRef.txOutRefId.buffer),
-            txOutRef.txOutRefIdx,
-            rr.rData.name,
-            Number(ttl),
-            content,
-          ],
-        },
+    return result.rows[0]!;
+  }
+
+  async insertDensRr(
+    outputWithDensElemId: {
+      elemTxOutRef: TxOutRef;
+      elemAssetClass: PlaV1.AssetClass;
+    },
+    rr: DensRr,
+  ) {
+    const { elemTxOutRef, elemAssetClass } = outputWithDensElemId;
+    const { ttl } = rr;
+    const content = validateDensRr(rr);
+
+    if (content === undefined) {
+      logger.info(
+        `Invalid RR from the tx with output with dens elem id ${
+          JSON.stringify(elemAssetClass)
+        } identifed by ${
+          JSON.stringify(
+            elemTxOutRef,
+            (_, v) => typeof v === "bigint" ? v.toString() : v,
+          )
+        }: ${
+          JSON.stringify(
+            rr,
+            (_, v) => typeof v === "bigint" ? v.toString() : v,
+          )
+        }`,
       );
+      return;
     }
+    await this.query(
+      {
+        text: `INSERT INTO dens_rrs(type, ttl, content, dens_elem_id) ` +
+          `SELECT $1, $2, $3, dens_elem_ids.id ` +
+          `FROM dens_elem_ids JOIN dens_set_utxos ON dens_elem_ids.asset_class = dens_set_utxos.pointer ` +
+          `WHERE dens_elem_ids.tx_out_ref_id = $4 AND dens_elem_ids.tx_out_ref_idx = $5 AND dens_elem_ids.asset_class = CAST(ROW($6, $7) AS asset_class) ` +
+          `AND dens_is_valid_name(dens_set_utxos.name)`,
+        values: [
+          rr.rData.name,
+          Number(ttl),
+          content,
+          Buffer.from(elemTxOutRef.txOutRefId.buffer),
+          elemTxOutRef.txOutRefIdx,
+          elemAssetClass[0],
+          elemAssetClass[1],
+        ],
+      },
+    );
   }
 
   async selectNamesRrs(name: Uint8Array): Promise<DensRr[]> {
     const res: QueryResult = await this.query(
       {
-        text: `SELECT type, ttl, content
-               FROM dens_rrs_utxos JOIN dens_rrs
-                ON dens_rrs_utxos.tx_out_ref_id = dens_rrs.tx_out_ref_id
-                    AND dens_rrs_utxos.tx_out_ref_idx = dens_rrs.tx_out_ref_idx
-               WHERE dens_rrs_utxos.name = CAST($1 AS bytea)
-               ORDER BY dens_rrs.id ASC`,
+        text: `SELECT type, ttl, content ` +
+          `FROM dens_elem_ids JOIN dens_rrs ON dens_elem_ids.id = dens_rrs.dens_elem_id JOIN dens_set_utxos ON dens_set_utxos.pointer = dens_elem_ids.asset_class ` +
+          `WHERE dens_set_utxos.name = CAST($1 AS bytea) ` +
+          `ORDER BY dens_rrs.id ASC`,
         values: [Buffer.from(name.buffer)],
       },
     );
@@ -447,7 +484,7 @@ class DensDbClient {
     const res: QueryResult = await this.query(
       {
         text:
-          `SELECT name, currency_symbol, token_name, tx_out_ref_id, tx_out_ref_idx, EXISTS (SELECT 1 FROM dens_set_utxos WHERE name=$1) AS is_already_inserted
+          `SELECT name, (pointer).currency_symbol, (pointer).token_name, tx_out_ref_id, tx_out_ref_idx, EXISTS (SELECT 1 FROM dens_set_utxos WHERE name=$1) AS is_already_inserted
            FROM dens_set_utxos
            WHERE name < $1
            ORDER BY name DESC
@@ -506,7 +543,8 @@ class DensDbClient {
     const res = await this.query(
       {
         text:
-          `SELECT * FROM (VALUES ((dens_set_protocol_nft($1, $2)).*) ) AS t (pk, currency_symbol, token_name)`,
+          `SELECT (t.asset_class).currency_symbol AS currency_symbol, (t.asset_class).token_name AS token_name 
+           FROM (VALUES ((dens_set_protocol_nft($1, $2)).*) ) AS t (pk, asset_class)`,
         values: [currencySymbol, tokenName],
       },
     );

--- a/dens-query/src/DensQuery/Logger.ts
+++ b/dens-query/src/DensQuery/Logger.ts
@@ -23,7 +23,7 @@ if (process.env["NODE_ENV"] !== "production") {
   logger.add(
     new winston.transports.Console(
       {
-        level: "info",
+        level: "verbose",
         format: winston.format.combine(
           winston.format.colorize(),
           winston.format.simple(),

--- a/dens-query/src/Tests/DbModel-test.ts
+++ b/dens-query/src/Tests/DbModel-test.ts
@@ -28,7 +28,6 @@ import * as assert from "node:assert/strict";
 import * as DbTestUtils from "./DbTestUtils.js";
 import * as Samples from "./Samples.js";
 import * as Db from "../DensQuery/Db.js";
-import * as PlaV1 from "plutus-ledger-api/V1.js";
 
 import * as Prelude from "prelude";
 import * as PMap from "prelude/Map.js";
@@ -55,9 +54,9 @@ type Model = {
 };
 
 /**
- * A command for {@link insertDensSetUtxo}
+ * A command for {@link upsertDensSetUtxo}
  */
-class InsertDensSetUtxoCommand implements fc.AsyncCommand<Model, Db.DensDb> {
+class UpsertDensSetUtxoCommand implements fc.AsyncCommand<Model, Db.DensDb> {
   #densSetRow: Db.DensSetUtxo;
   #point: Db.Point;
 
@@ -88,22 +87,14 @@ class InsertDensSetUtxoCommand implements fc.AsyncCommand<Model, Db.DensDb> {
 
       await client.insertPoint(this.#point);
       await client.insertTxOutRef(this.#densSetRow.txOutRef);
-      await client.insertDensSetUtxo(
-        [[
-          Prelude.fromJust(
-            PlaV1.currencySymbolFromBytes(
-              selectedProtocol.protocol.setElemMintingPolicy,
-            ),
-          ),
-          PlaV1.adaToken,
-        ]],
+      await client.upsertDensSetUtxo(
         this.#densSetRow,
       );
     });
   }
 
   toString() {
-    return `insertDensSetUtxo(${JSON.stringify(this.#densSetRow)})`;
+    return `upsertDensSetUtxo(${JSON.stringify(this.#densSetRow)})`;
   }
 }
 
@@ -155,7 +146,7 @@ it(`Database model tests`, async () => {
       const allCommands = [
         fc.tuple(Samples.fcPoint(), Samples.fcDensSetUtxo()).map((
           [point, densSetRow],
-        ) => new InsertDensSetUtxoCommand(point, densSetRow)),
+        ) => new UpsertDensSetUtxoCommand(point, densSetRow)),
         Samples.fcName().map((name) =>
           new StrictInfimumDensSetUtxoCommand(name)
         ),


### PR DESCRIPTION
What this does:
- Changes how RRs are propagated from blockchain to DB by: if a ElemID token is traded, all tx outputs in the current transaction with a datum that contains valid resource records are added to the database.